### PR TITLE
System calendar fixes

### DIFF
--- a/android/app/src/main/java/ke/mahn/gdqreminder/CalendarManager.java
+++ b/android/app/src/main/java/ke/mahn/gdqreminder/CalendarManager.java
@@ -26,6 +26,8 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -254,9 +256,10 @@ public class CalendarManager {
         return ret;
     }
 
-    public static void RefreshCalendarData(Context context) {
+    public static Exception RefreshCalendarData(Context context) {
         try {
-            URL uri = new URL("https://gamesdonequick.com/tracker/api/v1/search/?type=event&datetime_gte=" + Instant.now().toString());
+            Instant aroundAMonthAgo = Instant.now().minus(35, ChronoUnit.DAYS);
+            URL uri = new URL("https://gamesdonequick.com/tracker/api/v1/search/?type=event&datetime_gte=" + aroundAMonthAgo.toString());
             HttpURLConnection connection = (HttpURLConnection) uri.openConnection();
             connection.setRequestMethod("GET");
             connection.connect();
@@ -315,11 +318,13 @@ public class CalendarManager {
                         Instant.parse(fields.getString("endtime")).toEpochMilli(),
                         fields.getString("display_name"),
                         fields.getString("description"),
-                        fields.getString("setup_time")
+                        "https://twitch.tv/gamesdonequick"
                 );
             }
+            return null;
         } catch (Exception e) {
             e.printStackTrace();
+            return e;
         }
     }
 }

--- a/android/app/src/main/java/ke/mahn/gdqreminder/CalendarManager.java
+++ b/android/app/src/main/java/ke/mahn/gdqreminder/CalendarManager.java
@@ -27,7 +27,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/android/app/src/main/java/ke/mahn/gdqreminder/RefreshTimesForCurrentEvent.java
+++ b/android/app/src/main/java/ke/mahn/gdqreminder/RefreshTimesForCurrentEvent.java
@@ -7,19 +7,8 @@ import androidx.concurrent.futures.CallbackToFutureAdapter;
 import androidx.work.ListenableWorker;
 import androidx.work.WorkerParameters;
 
-import com.getcapacitor.JSArray;
 import com.google.common.util.concurrent.ListenableFuture;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
-
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.time.Instant;
-import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;

--- a/android/app/src/main/java/ke/mahn/gdqreminder/RefreshTimesForCurrentEvent.java
+++ b/android/app/src/main/java/ke/mahn/gdqreminder/RefreshTimesForCurrentEvent.java
@@ -35,81 +35,16 @@ public class RefreshTimesForCurrentEvent extends ListenableWorker {
     @Override
     public ListenableFuture<Result> startWork() {
         return CallbackToFutureAdapter.getFuture(completer -> {
-            Runnable runnable = new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        URL uri = new URL("https://gamesdonequick.com/tracker/api/v1/search/?type=event&datetime_gte=" + Instant.now().toString());
-                        HttpURLConnection connection = (HttpURLConnection) uri.openConnection();
-                        connection.setRequestMethod("GET");
-                        connection.connect();
-                        int responseCode = connection.getResponseCode();
-                        if (responseCode != HttpURLConnection.HTTP_OK) {
-                            throw new Exception("event HTTP response code: " + responseCode);
-                        }
-
-                        InputStream inputStream = connection.getInputStream();
-                        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-                        StringBuilder response = new StringBuilder();
-                        String line;
-                        while ((line = reader.readLine()) != null) {
-                            response.append(line);
-                        }
-                        reader.close();
-                        inputStream.close();
-                        JSArray events = new JSArray(response.toString());
-                        String currentShort = events.getJSONObject(0).getJSONObject("fields").getString("short");
-                        uri = new URL("https://gamesdonequick.com/tracker/api/v1/search/?type=run&eventshort=" + currentShort);
-                        connection = (HttpURLConnection) uri.openConnection();
-                        connection.setRequestMethod("GET");
-                        connection.connect();
-                        responseCode = connection.getResponseCode();
-                        if (responseCode != HttpURLConnection.HTTP_OK) {
-                            throw new Exception("run HTTP response code: " + responseCode);
-                        }
-                        inputStream = connection.getInputStream();
-                        reader = new BufferedReader(new InputStreamReader(inputStream));
-                        response = new StringBuilder();
-                        while ((line = reader.readLine()) != null) {
-                            response.append(line);
-                        }
-                        reader.close();
-                        inputStream.close();
-                        JSONArray runs = new JSONArray(response.toString());
-                        JSONArray trackedPKs = CalendarManager.internalGetAllEvents(context).getJSONArray("events");
-                        List<String> trackedPKsList = new java.util.ArrayList<>();
-                        for (int i = 0; i < trackedPKs.length(); i++) {
-                            trackedPKsList.add(trackedPKs.getJSONObject(i).getString("pk"));
-                        }
-
-                        for (int i = 0; i < runs.length(); i++) {
-                            JSONObject fields = runs.getJSONObject(i).getJSONObject("fields");
-                            String pk = runs.getJSONObject(i).getString("pk");
-
-                            if (!trackedPKsList.contains(pk)) {
-                                continue;
-                            }
-
-                            CalendarManager.internalUpsertEvent(
-                                    context,
-                                    CalendarManager.InsertCalendarIfMissing(context),
-                                    runs.getJSONObject(i).getString("pk"),
-                                    Instant.parse(fields.getString("starttime")).toEpochMilli(),
-                                    Instant.parse(fields.getString("endtime")).toEpochMilli(),
-                                    fields.getString("display_name"),
-                                    fields.getString("description"),
-                                    fields.getString("setup_time")
-                            );
-                        }
-                        completer.set(Result.success());
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                        completer.set(Result.failure());
-                    }
+            Runnable runnable = () -> {
+                Exception exception = CalendarManager.RefreshCalendarData(context);
+                if (exception != null) {
+                    completer.set(Result.failure());
+                    return;
                 }
+
+                completer.set(Result.success());
             };
 
-            // Create a ThreadPoolExecutor with a single thread
             ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
             executor.execute(runnable);
 

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 22
+    minSdkVersion = 26
     compileSdkVersion = 34
     targetSdkVersion = 34
     androidxActivityVersion = '1.8.0'


### PR DESCRIPTION
System calendar entries were created and removed when a user interacted with the schedule, but not automatically in the background, even though a job was present.

- Background job failed right when an event started, as it was looking for events with start times later than now (thereby selecting the event next up, rather than the one currently in progress) 
- No longer replaces the twitch.tv link inside the location field with the setup time
- Removes redundant code + imports