### PR TITLE
Prevents run list from getting stuck behind header or safe area inserts after switching filter view

### DIFF
--- a/src/components/GDQMain.vue
+++ b/src/components/GDQMain.vue
@@ -60,6 +60,7 @@ interface TopAppBarFixedWithOpen extends TopAppBarFixed {
 export default defineComponent({
   async setup() {
     const scrollable = ref<HTMLDivElement>();
+    const wrapper = ref<HTMLDivElement>();
     provide<(x: number, y: number) => void>(
       "scrollRunContainerBy",
       (x: number, y: number) => {
@@ -74,6 +75,7 @@ export default defineComponent({
         header.style.overflow = "visible";
 
         scrollable.value!.querySelector("#runs")!.scrollBy(x, y);
+        wrapper.value!.scrollTop = 0;
       },
     );
 
@@ -582,6 +584,7 @@ export default defineComponent({
       runners,
       reminder,
       scrollable,
+      wrapper,
       toggleFilter,
       toggleDarkMode,
       generateContainerClassNames: () => {
@@ -606,7 +609,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <div :class="generateContainerClassNames()">
+  <div ref="wrapper" :class="generateContainerClassNames()">
     <!-- eslint-disable vue/no-deprecated-slot-attribute false positive: -->
     <!-- google uses 'slot' as a prop name, so we need to disable this rule, as it's a false positive -->
     <md-dialog ref="dialog">


### PR DESCRIPTION
Resolveslayout issues appearing after tapping the filter icon: 
| | |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ad204ee8-3ddc-4b9c-9713-f33a028f116f) | ![image](https://github.com/user-attachments/assets/750b125a-fab8-4f26-9530-b6df4a7a2544) |
